### PR TITLE
Add support for documents (and schedule reports)

### DIFF
--- a/src/libpst.c
+++ b/src/libpst.c
@@ -2276,6 +2276,8 @@ static int pst_process(uint64_t block_id, pst_mapi_object *list, pst_item *item,
                             item->type = PST_TYPE_CONTACT;
                         else if (pst_strincmp("REPORT.IPM.Note", item->ascii_type, 15) == 0)
                             item->type = PST_TYPE_REPORT;
+                        else if (pst_strincmp("REPORT.IPM.Schedule.Meeting", item->ascii_type, 27) == 0)
+                            item->type = PST_TYPE_REPORT;
                         else if (pst_strincmp("IPM.Activity", item->ascii_type, 12) == 0)
                             item->type = PST_TYPE_JOURNAL;
                         else if (pst_strincmp("IPM.Appointment", item->ascii_type, 15) == 0)
@@ -2286,6 +2288,8 @@ static int pst_process(uint64_t block_id, pst_mapi_object *list, pst_item *item,
                             item->type = PST_TYPE_STICKYNOTE;
                         else if (pst_strincmp("IPM.Task", item->ascii_type, 8) == 0)
                             item->type = PST_TYPE_TASK;
+                        else if (pst_strincmp("IPM.Document", item->ascii_type, 12) == 0)
+                            item->type = PST_TYPE_DOCUMENT;
                         else
                             item->type = PST_TYPE_OTHER;
                         DEBUG_INFO(("Message class %s [%"PRIi32"] \n", item->ascii_type, item->type));

--- a/src/libpst.h
+++ b/src/libpst.h
@@ -25,6 +25,7 @@
 
 #define PST_TYPE_NOTE        1
 #define PST_TYPE_SCHEDULE    2
+#define PST_TYPE_DOCUMENT    3
 #define PST_TYPE_APPOINTMENT 8
 #define PST_TYPE_CONTACT     9
 #define PST_TYPE_JOURNAL    10
@@ -797,6 +798,7 @@ typedef struct pst_item {
     /** derived from mapi elements 0x001a PR_MESSAGE_CLASS or 0x3613 PR_CONTAINER_CLASS
      *  @li  1 PST_TYPE_NOTE
      *  @li  2 PST_TYPE_SCHEDULE
+     *  @li  3 PST_TYPE_DOCUMENT
      *  @li  8 PST_TYPE_APPOINTMENT
      *  @li  9 PST_TYPE_CONTACT
      *  @li 10 PST_TYPE_JOURNAL


### PR DESCRIPTION
A client reported a pst with missing items (comparing our platform extraction to Outlook). These extra items turned out to be:

* Raw emls stored using the [Document Object Protocol](https://msdn.microsoft.com/en-us/library/cc425491(v=exchg.80).aspx)
* A few [delivery/read reports for meetings](https://msdn.microsoft.com/en-us/library/ee200767(v=exchg.80).aspx)

The document object protocol looks like a simple wrapper around a single attachment. Hopefully this isn't too common among all the psts we've already processed...