### PR TITLE
Check nid type?

### DIFF
--- a/src/libpst.c
+++ b/src/libpst.c
@@ -2272,6 +2272,12 @@ static int pst_process(uint64_t block_id, pst_mapi_object *list, pst_item *item,
                             item->type = PST_TYPE_NOTE;
                         else if (pst_stricmp("IPM", item->ascii_type) == 0)
                             item->type = PST_TYPE_NOTE;
+                        else if (pst_stricmp("IPM.Outlook.Recall", item->ascii_type) == 0)
+                            item->type = PST_TYPE_NOTE;
+                        else if (pst_strincmp("IPM.Post", item->ascii_type, 8) == 0)
+                            item->type = PST_TYPE_POST;
+                        else if (pst_strincmp("IPM.Sharing", item->ascii_type, 11) == 0)
+                            item->type = PST_TYPE_SHARE;
                         else if (pst_strincmp("IPM.Contact", item->ascii_type, 11) == 0)
                             item->type = PST_TYPE_CONTACT;
                         else if (pst_strincmp("REPORT.IPM.Note", item->ascii_type, 15) == 0)

--- a/src/libpst.h
+++ b/src/libpst.h
@@ -26,6 +26,8 @@
 #define PST_TYPE_NOTE        1
 #define PST_TYPE_SCHEDULE    2
 #define PST_TYPE_DOCUMENT    3
+#define PST_TYPE_POST        4
+#define PST_TYPE_SHARE       5
 #define PST_TYPE_APPOINTMENT 8
 #define PST_TYPE_CONTACT     9
 #define PST_TYPE_JOURNAL    10

--- a/src/readpst.c
+++ b/src/readpst.c
@@ -323,7 +323,7 @@ int process(pst_item *outeritem, pst_desc_tree *d_ptr)
                 if (mode == MODE_SEPARATE) close_separate_file(&ff);
             }
 
-        } else if (item->email && ((item->type == PST_TYPE_NOTE) || (item->type == PST_TYPE_SCHEDULE) || (item->type == PST_TYPE_REPORT) || item->type == PST_TYPE_STICKYNOTE || item->type == PST_TYPE_TASK)) {
+        } else if (item->email && (item->type == PST_TYPE_NOTE || item->type == PST_TYPE_SCHEDULE || item->type == PST_TYPE_REPORT || item->type == PST_TYPE_STICKYNOTE || item->type == PST_TYPE_TASK || item->type == PST_TYPE_POST || item->type == PST_TYPE_SHARE)) {
             ff.found_count++;
             DEBUG_INFO(("Processing Email\n"));
             if (!(output_type_mode & OTMODE_EMAIL)) {
@@ -425,7 +425,7 @@ int process(pst_item *outeritem, pst_desc_tree *d_ptr)
         }
         pst_freeItem(item);
     }
-    success &= ff.found_count == ff.stored_count;
+    success &= (! outeritem->folder || ff.found_count == ff.stored_count) && ff.skip_count == 0;
     close_enter_dir(&ff);
     DEBUG_RET();
     return success;
@@ -870,6 +870,8 @@ int32_t reduced_item_type(int32_t item_type) {
         case PST_TYPE_NOTE:
         case PST_TYPE_OTHER:
         case PST_TYPE_REPORT:
+        case PST_TYPE_POST:
+        case PST_TYPE_SHARE:
         default:
             reduced = PST_TYPE_NOTE;
             break;

--- a/src/readpst.c
+++ b/src/readpst.c
@@ -268,7 +268,8 @@ int process(pst_item *outeritem, pst_desc_tree *d_ptr)
         if (item->subject.str) {
             DEBUG_INFO(("item->subject = %s\n", item->subject.str));
         }
-        if (item->folder && item->file_as.str) {
+        int nid_type = d_ptr->d_id & 0x1f;
+        if ((nid_type == 0x2 || nid_type == 0x3 || nid_type == 0xB || nid_type == 0xC) && item->folder && item->file_as.str) {
             DEBUG_INFO(("Processing Folder \"%s\"\n", item->file_as.str));
             if (output_mode != OUTPUT_QUIET) {
                 pst_debug_lock();

--- a/src/readpst.c
+++ b/src/readpst.c
@@ -12,7 +12,7 @@
 #define OUTPUT_TEMPLATE "%s.%s"
 #define OUTPUT_KMAIL_DIR_TEMPLATE ".%s.directory"
 #define KMAIL_INDEX "../.%s.index"
-#define SEP_MAIL_FILE_TEMPLATE "%i%s"
+#define SEP_MAIL_FILE_TEMPLATE "%lx%s"
 
 // max size of the c_time char*. It will store the date of the email
 #define C_TIME_SIZE 500
@@ -40,7 +40,7 @@ void      mk_recurse_dir(char* dir);
 int       close_recurse_dir();
 void      mk_separate_dir(char *dir);
 int       close_separate_dir();
-void      mk_separate_file(struct file_ll *f, int32_t t, char *extension, int openit);
+void      mk_separate_file(struct file_ll *f, int32_t t, pst_desc_tree *d_ptr, char *extension, int openit);
 void      close_separate_file(struct file_ll *f);
 char*     my_stristr(char *haystack, char *needle);
 void      check_filename(char *fname);
@@ -310,7 +310,7 @@ int process(pst_item *outeritem, pst_desc_tree *d_ptr)
             }
             else {
                 ff.item_count++;
-                if (mode == MODE_SEPARATE) mk_separate_file(&ff, PST_TYPE_CONTACT, (mode_EX) ? ".vcf" : "", 1);
+                if (mode == MODE_SEPARATE) mk_separate_file(&ff, PST_TYPE_CONTACT, d_ptr, (mode_EX) ? ".vcf" : "", 1);
                 if (contact_mode == CMODE_VCARD) {
                     pst_convert_utf8_null(item, &item->comment);
                     write_vcard(ff.output[PST_TYPE_CONTACT], item, item->contact, item->comment.str);
@@ -340,11 +340,11 @@ int process(pst_item *outeritem, pst_desc_tree *d_ptr)
                     if (child == 0) {
                         // we are the child process, or the original parent if no children were available
                         pid_t me = getpid();
-                        mk_separate_file(&ff, PST_TYPE_NOTE, (mode_EX) ? ".eml" : "", 1);
+                        mk_separate_file(&ff, PST_TYPE_NOTE, d_ptr, (mode_EX) ? ".eml" : "", 1);
                         write_normal_email(ff.output[PST_TYPE_NOTE], ff.name[PST_TYPE_NOTE], item, mode, mode_MH, &pstfile, save_rtf_body, PST_TYPE_NOTE, &extra_mime_headers);
                         close_separate_file(&ff);
                         if (mode_MSG) {
-                            mk_separate_file(&ff, PST_TYPE_NOTE, ".msg", 0);
+                            mk_separate_file(&ff, PST_TYPE_NOTE, d_ptr, ".msg", 0);
                             write_msg_email(ff.name[PST_TYPE_NOTE], item, &pstfile);
                         }
 #ifdef HAVE_FORK
@@ -376,7 +376,7 @@ int process(pst_item *outeritem, pst_desc_tree *d_ptr)
             }
             else {
                 ff.item_count++;
-                if (mode == MODE_SEPARATE) mk_separate_file(&ff, PST_TYPE_JOURNAL, (mode_EX) ? ".ics" : "", 1);
+                if (mode == MODE_SEPARATE) mk_separate_file(&ff, PST_TYPE_JOURNAL, d_ptr, (mode_EX) ? ".ics" : "", 1);
                 write_journal(ff.output[PST_TYPE_JOURNAL], item);
                 fprintf(ff.output[PST_TYPE_JOURNAL], "\n");
                 if (mode == MODE_SEPARATE) close_separate_file(&ff);
@@ -391,7 +391,7 @@ int process(pst_item *outeritem, pst_desc_tree *d_ptr)
             }
             else {
                 ff.item_count++;
-                if (mode == MODE_SEPARATE) mk_separate_file(&ff, PST_TYPE_APPOINTMENT, (mode_EX) ? ".ics" : "", 1);
+                if (mode == MODE_SEPARATE) mk_separate_file(&ff, PST_TYPE_APPOINTMENT, d_ptr, (mode_EX) ? ".ics" : "", 1);
                 write_schedule_part_data(ff.output[PST_TYPE_APPOINTMENT], item, NULL, NULL);
                 fprintf(ff.output[PST_TYPE_APPOINTMENT], "\n");
                 if (mode == MODE_SEPARATE) close_separate_file(&ff);
@@ -414,7 +414,7 @@ int process(pst_item *outeritem, pst_desc_tree *d_ptr)
                 DEBUG_INFO(("Attempting document extraction\n"));
                 if ((attach->data.data || attach->i_id) && acceptable_ext(attach)) {
                     ff.item_count++;
-                    mk_separate_file(&ff, PST_TYPE_DOCUMENT, "", 0);
+                    mk_separate_file(&ff, PST_TYPE_DOCUMENT, d_ptr, "", 0);
                     write_separate_attachment(ff.name[PST_TYPE_DOCUMENT], attach, ++attach_num, &pstfile);
                 }
             }
@@ -919,7 +919,7 @@ void mk_separate_dir(char *dir) {
         if (y == 0)
             snprintf(dir_name, dirsize, "%s", dir);
         else
-            snprintf(dir_name, dirsize, "%s" SEP_MAIL_FILE_TEMPLATE, dir, y, ""); // enough for 9 digits allocated above
+            snprintf(dir_name, dirsize, "%s%i", dir, y); // enough for 9 digits allocated above
 
         check_filename(dir_name);
         DEBUG_INFO(("about to try creating %s\n", dir_name));
@@ -978,13 +978,10 @@ int close_separate_dir() {
 }
 
 
-void mk_separate_file(struct file_ll *f, int32_t t, char *extension, int openit) {
+void mk_separate_file(struct file_ll *f, int32_t t, pst_desc_tree *d_ptr, char *extension, int openit) {
     DEBUG_ENT("mk_separate_file");
     DEBUG_INFO(("opening next file to save email type %s\n", item_type_to_name(t)));
-    if (f->item_count > 999999999) { // bigger than nine 9's
-        DIE(("mk_separate_file: The number of emails in this folder has become too high to handle\n"));
-    }
-    sprintf(f->name[t], SEP_MAIL_FILE_TEMPLATE, f->item_count, extension);
+    sprintf(f->name[t], SEP_MAIL_FILE_TEMPLATE, d_ptr->d_id >> 5, extension);
     check_filename(f->name[t]);
     if (openit) {
         if (!(f->output[t] = fopen(f->name[t], "w"))) {

--- a/src/readpst.c
+++ b/src/readpst.c
@@ -269,7 +269,7 @@ int process(pst_item *outeritem, pst_desc_tree *d_ptr)
             DEBUG_INFO(("item->subject = %s\n", item->subject.str));
         }
         int nid_type = d_ptr->d_id & 0x1f;
-        if ((nid_type == 0x2 || nid_type == 0x3 || nid_type == 0xB || nid_type == 0xC) && item->folder && item->file_as.str) {
+        if (nid_type == 0x2 && item->folder && item->file_as.str) {
             DEBUG_INFO(("Processing Folder \"%s\"\n", item->file_as.str));
             if (output_mode != OUTPUT_QUIET) {
                 pst_debug_lock();
@@ -323,7 +323,7 @@ int process(pst_item *outeritem, pst_desc_tree *d_ptr)
                 if (mode == MODE_SEPARATE) close_separate_file(&ff);
             }
 
-        } else if (item->email && ((item->type == PST_TYPE_NOTE) || (item->type == PST_TYPE_SCHEDULE) || (item->type == PST_TYPE_REPORT))) {
+        } else if (item->email && ((item->type == PST_TYPE_NOTE) || (item->type == PST_TYPE_SCHEDULE) || (item->type == PST_TYPE_REPORT) || item->type == PST_TYPE_STICKYNOTE || item->type == PST_TYPE_TASK)) {
             ff.found_count++;
             DEBUG_INFO(("Processing Email\n"));
             if (!(output_type_mode & OTMODE_EMAIL)) {


### PR DESCRIPTION
CS reported a pst with no reported errors that was clearly not expanding fully.
It looks like many of the message objects it contains have property 0x3603 (PidTagContentUnreadCount) which is normally a folder property; when `libpst` encounters it it initializes the `folder` structure.  On traversal these objects get typed as folders based on the presence of that structure and ultimately ignored. I'm not sure whether to consider this a violation of the spec - it's not explicitly forbidden outside of folders and I think Outlook opens it correctly (although I'm still confirming that).

Each node has a type field as well, so we could use that to determine what it contains, rather than guess based on its properties. However, I'm not sure whether to:

* Switch entirely to using this node id (and whether some of the stranger node types have any content, e.g. `NID_TYPE_RECEIVE_FOLDER_TABLE`)
* Keep the current "duck typing" approach (with more appropriate folder detection that requires all four of the mandatory folder properties)
* Do something in between (ala the current version of this PR)

Do you have any thoughts or suggestions here?