### PR TITLE
Feature/error detection

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT(libpst,0.6.70,carl@five-ten-sg.com)
+AC_INIT(libpst,0.6.70.1,carl@five-ten-sg.com)
 AC_CONFIG_SRCDIR([src/libpst.c])
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
Pulled out only the error-detection/reporting code from the other PR.  This change shouldn't have any naming-related consequences, it'll just mark PSTs with unextracted content as having errors. I've made a corresponding change on the worker side so that when this situation occurs, we'll still generate children for the docs we do find, so the net result should just be that the psts are marked as examine errors.